### PR TITLE
Fix support for callables in requestHeaders

### DIFF
--- a/reste.js
+++ b/reste.js
@@ -77,7 +77,7 @@ function makeHttpRequest(args, onLoad, onError) {
             formEncode = true;
         }
 
-        http.setRequestHeader(header.name, typeof header.value == "function" ? header.value : header.value);
+        http.setRequestHeader(header.name, typeof header.value == "function" ? header.value() : header.value);
     });
 
     // non-global headers


### PR DESCRIPTION
Looks like the support was there but was passing the function to setRequestHeader rather than the output of the function
