### PR TITLE
simple Promise support with q.js

### DIFF
--- a/reste.js
+++ b/reste.js
@@ -4,8 +4,7 @@ var main = function() {
 
     // setup vars
     var config = {},
-        requestHeaders = [],
-        Q;
+        requestHeaders = [];
 
     // generic log handler in DEV mode
     function log(message) {
@@ -32,10 +31,6 @@ var main = function() {
             config.models.forEach(function(model) {
                 reste.addModel(model);
             });
-        }
-        
-        if (config.Q) {
-            Q = config.Q;
         }
 
     };
@@ -219,8 +214,8 @@ var main = function() {
 
             url = args[method.toLowerCase()] || args.get;
             
-            if (Q && !onLoad && !onError) {
-                deferred = Q.defer();
+            if (config.Q && !onLoad && typeof(params) != "function" ) {
+                deferred = config.Q.defer();
                 onLoad = deferred.resolve;
                 onError = deferred.reject;
             }

--- a/reste.js
+++ b/reste.js
@@ -4,7 +4,8 @@ var main = function() {
 
     // setup vars
     var config = {},
-        requestHeaders = [];
+        requestHeaders = [],
+        Q;
 
     // generic log handler in DEV mode
     function log(message) {
@@ -31,6 +32,10 @@ var main = function() {
             config.models.forEach(function(model) {
                 reste.addModel(model);
             });
+        }
+        
+        if (config.Q) {
+            Q = config.Q;
         }
 
     };
@@ -204,7 +209,8 @@ var main = function() {
             var body,
                 method = "GET",
                 url,
-                onError;
+                onError,
+                deferred;
 
             if (args.post) method = "POST";
             if (args.get) method = "GET";
@@ -212,7 +218,13 @@ var main = function() {
             if (args.delete) method = "DELETE";
 
             url = args[method.toLowerCase()] || args.get;
-
+            
+            if (Q && !onLoad && !onError) {
+                deferred = Q.defer();
+                onLoad = deferred.resolve;
+                onError = deferred.reject;
+            }
+            
             if (!onLoad && typeof(params) == "function") {
                 onLoad = params;
             } else {
@@ -292,6 +304,10 @@ var main = function() {
                         headers: args.requestHeaders || args.headers,
                     }, onLoad, onError);
                 }
+            }
+            
+            if (deferred) {
+                return deferred.promise;
             }
         };
     };


### PR DESCRIPTION
very simple Promise support using q.js. It doesn't add q.js dependency, thus backwards compatible. Just pass Q object to config as config.Q property and don't pass callbacks. If callback passed it'll use callbacks instead of Promise.
