### PR TITLE
validatesSecureCertificate support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,7 @@ var api = new reste();
 api.config({
     debug: true, // allows logging to console of ::REST:: messages
     autoValidateParams: false, // set to true to throw errors if <param> url properties are not passed
+    validatesSecureCertificate: false, // set to true to force SSL certificate on HTTPS calls to be valid
     timeout: 4000,
     url: "https://api.parse.com/1/",
     requestHeaders: {

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ var api = new reste();
 api.config({
     debug: true, // allows logging to console of ::REST:: messages
     autoValidateParams: false, // set to true to throw errors if <param> url properties are not passed
-    validatesSecureCertificate: false, // set to true to force SSL certificate on HTTPS calls to be valid
+    validatesSecureCertificate: false, // Optional: If not specified, default behaviour from http://goo.gl/sJvxzS is kept.
     timeout: 4000,
     url: "https://api.parse.com/1/",
     requestHeaders: {

--- a/reste.js
+++ b/reste.js
@@ -78,7 +78,9 @@ var main = function() {
 
         //set some defaults
         http.setTimeout(config.timeout || 10000);
-        http.setValidatesSecureCertificate(config.validatesSecureCertificate || true);
+        if (config.validatesSecureCertificate) {
+            http.setValidatesSecureCertificate(config.validatesSecureCertificate);
+        }
 
         // open the url
         http.open(args.method, (config.url ? config.url + args.url : args.url));

--- a/reste.js
+++ b/reste.js
@@ -78,6 +78,7 @@ var main = function() {
 
         //set some defaults
         http.setTimeout(config.timeout || 10000);
+        http.setValidatesSecureCertificate(config.validatesSecureCertificate || true);
 
         // open the url
         http.open(args.method, (config.url ? config.url + args.url : args.url));


### PR DESCRIPTION
Sometimes you don't want to validate SSL certificate on API calls.
For example I use HTTPS calls to my API but the certificate is not validated (yet) but I still want to be able to use HTTPS encryption in the meantime.
Default behaviour is kept from http://docs.appcelerator.com/platform/latest/#!/api/Titanium.Network.HTTPClient-property-validatesSecureCertificate if not specified (`false` when running in the simulator or on device in testing mode, and `true` if built for release in distribution mode.)
