### PR TITLE
Request headers must be set after http.open()

### DIFF
--- a/reste.js
+++ b/reste.js
@@ -92,7 +92,6 @@ var main = function() {
             http.open(args.method, args.url);
 
         } else {
-
             http.open(args.method, (config.url ? config.url + args.url : args.url));
 
             // load up any global request headers
@@ -101,8 +100,12 @@ var main = function() {
                     formEncode = true;
                 }
                 http.setRequestHeader(header.name, typeof header.value == "function" ? header.value() : header.value);
-            });
 
+                if (config.debug) {
+                    console.log("::RESTE:: Sending request headers");
+                    console.log(typeof header == "function" ? header() : header);
+                }
+            });
         }
 
         // non-global headers


### PR DESCRIPTION
Setting headers through the `config` using `requestHeaders` wasn't working for me.

It turns out that according to the [documentation](http://docs.appcelerator.com/platform/latest/#!/api/Titanium.Network.HTTPClient-method-setRequestHeader) the method `setRequestHeader()` must be called after `open()`.

This fixes that, plus adds additional debugging messages. 