### PR TITLE
Fixes bug using a model with non-array returned data

### DIFF
--- a/reste.js
+++ b/reste.js
@@ -587,10 +587,15 @@ var main = function() {
 
                             if (modelConfig.content) {
 
-                                var results = e[modelConfig.content];
+                                var result = e[modelConfig.content];
 
-                                if (results.length === 1) {
-                                    options.success(results[0]);
+                                if (result.length === 1) {
+                                    //result is an array with value as first entry
+                                    options.success(result[0]);
+                                }
+                                else {
+                                    //result is not an array
+                                    options.success(result);
                                 }
                             } else {
                                 // calls error handler if we have it defined and 201+ returned


### PR DESCRIPTION
Fixes bug where using a model only (with no collection) and the api returns an object say, rather than an array.