### PR TITLE
return the HTTPClient  to allow abort the call

### DIFF
--- a/reste.js
+++ b/reste.js
@@ -158,7 +158,7 @@ var main = function() {
 
             function retry() {
                 log('Retrying...');
-                makeHttpRequest(args, onLoad, onError);
+                return  makeHttpRequest(args, onLoad, onError);
             }
 
             var error;
@@ -226,7 +226,7 @@ var main = function() {
         } else {
             send();
         }
-
+        return http;
     }
 
     // set Requestheaders
@@ -338,7 +338,7 @@ var main = function() {
                     }
                 });
 
-                makeHttpRequest({
+                return  makeHttpRequest({
                     url : url,
                     method : method,
                     params : body,
@@ -370,7 +370,7 @@ var main = function() {
                     throw 'RESTe :: missing parameter/s ' + missing + ' for method ' + args.name;
                 } else {
 
-                    makeHttpRequest({
+                    return makeHttpRequest({
                         url : url,
                         method : method,
                         params : body,


### PR DESCRIPTION
Returning the HTTPClient I was able to abort the call. 


test case: 

```
const reste = require("reste")
const api = new reste()
api.config({
	debug: true, // allows logging to console of ::REST:: messages
	timeout: 4000,
	errorsAsObjects: true,
	url: "https://httpbin.org/",
	methods: [
		{
			name: "delayed",
			get: "delay/<seconds>"
		}
	],
	onError(e) {
		console.log(e)
	},
	onLoad(e, callback) {
		console.log("onLoad")
	}
})

const delayedRequest = api.delayed({ seconds: 5 })

setTimeout(() => {
	console.log("aborting after 2 sec")
	delayedRequest.abort()
}, 2000)
```
 #42