### PR TITLE
Skip property in beforeLoad callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reste",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "A JavaScript REST / API helper for Titanium with Alloy Models/Collections support",
   "titaniumManifest": {
     "guid": "afafe8b0-b93b-771c-a9e5-4e71db81b9ff"

--- a/readme.md
+++ b/readme.md
@@ -141,11 +141,11 @@ api.config({
 
 A couple of useful hooks or events can be used within your RESTe global configuration. Those hooks will happen before specific calls are made. They will be executed before any request is sent allowing you to a) change the parameters or b) stop the call happening.
 
-beforePost:
+#### beforePost:
 
 This one is quite useful if you need to change the parameters which are going to be used for the request. You might for example -- if you're using Parse Server -- want to strip out certain parameters from models before sending them.
 
-Example:
+**Example:**
 ```javascript
 {
     ...
@@ -156,11 +156,12 @@ Example:
     ...
 }
 ```
-beforeSend:
 
-These are similar to beforeSend but works for all requests (GET, PUT, DELETE, POST). If you specify both beforePost and beforeLoad then beforePost will go first, then beforeSend.
+#### beforeSend:
 
-Example:
+These are similar to beforeSend but works for all requests (GET, PUT, DELETE, POST). If you specify both `beforePost` and `beforeLoad` then `beforePost` will go first, then `beforeSend`. Inside `beforeSend` or `beforePost` you can call the `callback()` method with `skip:true` so it will still fire your `success` callback but _without_ making the API call. Use this e.g. to load offline fallback data inside your `success` method:
+
+**Example:**
 ```javascript
 {
     ...
@@ -169,6 +170,11 @@ Example:
 	    callback(data);
 	} else {
 	    alert("No internet connection!");
+      callback({
+        skip: true,
+        error: "no_internet"
+      });
+      // will call your success method and pass `error:no_internet` to it
 	}
     },
     ...

--- a/readme.md
+++ b/readme.md
@@ -150,8 +150,8 @@ This one is quite useful if you need to change the parameters which are going to
 {
     ...
     beforePost: function(params, callback) {
-	params.something = 'else';
-        callback(params);
+      params.something = 'else';
+      callback(params);
     },
     ...
 }
@@ -166,18 +166,18 @@ These are similar to beforeSend but works for all requests (GET, PUT, DELETE, PO
 {
     ...
     beforeSend: function(data, callback) {
-	if (Ti.Network.online) {
-	    callback(data);
-	} else {
-	    alert("No internet connection!");
-      callback({
-        skip: true,
-        error: "no_internet"
-      });
-      // will call your success method and pass `error:no_internet` to it
-	}
-    },
-    ...
+      if (Ti.Network.online) {
+        callback(data);
+       } else {
+         alert("No internet connection!");
+         callback({
+           skip: true,
+           error: "no_internet"
+         });
+         // will call your success method and pass `error:no_internet` to it
+       }
+     },
+     ...
 }
 ```
 ### Errors
@@ -283,13 +283,13 @@ Here's a **PUT** request example, passing an id (you'd need to ensure you have a
 
 ```javascript
 api.updateVideo({
-	objectId: "123",
-	body: {
-		categoryId: 2,
-		name: "My Video2"
-	}
+  objectId: "123",
+  body: {
+    categoryId: 2,
+    name: "My Video2"
+  }
 }, function(video) {
-	// do stuff with the video
+  // do stuff with the video
 });
 ```
 

--- a/reste.js
+++ b/reste.js
@@ -179,11 +179,19 @@ function main() {
     if (args.method === 'POST' && typeof beforePost === 'function') {
 
       beforePost(args.params, (e) => {
+        if (e.skip) {
+            onLoad(e);
+            return;
+        }
         args.params = e;
         send();
       });
     } else if (typeof beforeSend === 'function') {
       beforeSend(args.params, (e) => {
+        if (e.skip) {
+            onLoad(e);
+            return;
+        }
         args.params = e;
         send();
       });


### PR DESCRIPTION
Adding a `skip` property in the beforeLoad/post callback. 
With this I can run:

```js
beforeSend: function(data, callback) {
	if (Ti.Network.online) {
		callback(data);
	} else {
		alert("No internet connection!");
		callback({
			skip: true,
			error: "no_internet"
		});
		// will call your success method and pass `error:no_internet` to it
	}
}
```

it it will call still the `success` method of my api call but without making the request (no internet!). Inside the `success` I can hide a loader and use local data for example.

```js
api.getEvents({}, function(data) {
  if (data.error && data.error == "no_internet") {
    // do local stuff
  } else {
    // do normal stuff
  }
});
```

I'm using this in my app already and it works fine.

---

Also adding some minor changes to the README